### PR TITLE
Remove amount field from campaign leaderboard sample response

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -109,7 +109,6 @@ module EverydayHero
 
     CampaignLeaderboardData = {
       campaign_id: 'au-1',
-      amount: Money.new('1000', 'au').attributes,
       page_ids: [1, 2]
     }
 


### PR DESCRIPTION
The campaign leaderboard (http://developer.everydayhero.com/leaderboards/#view-a-campaign-leaderboard) no longer returns the amount. This doco change is in relation to the following code change:

https://github.com/everydayhero/fundraiser/commit/a57a15a9a239cd882c53db46667119abb9e408de#app/serializers/campaign_leaderboard_serializer.rb
