### PR TITLE
PS-68 add new branding solution for integrations

### DIFF
--- a/content/oauth-integration.md
+++ b/content/oauth-integration.md
@@ -95,6 +95,18 @@ name
 : _Optional_ **string**. The full name of the person you want to
 prepopulate the sign-up form for.
 
+### Branding
+
+Branding is optional.
+
+These parameters are only required if you would like branding from your campaign to be used for the sign up/in screen. If you choose to implement branding, both parameters are required.
+
+reference
+: _Optional_ **string**. The campaign slug for the campaign which should be used for branding the login screen.
+
+country
+: _Optional_ **string**. The country code associated with your campaign (au, nz, uk)
+
 ## Token endpoint
 
     POST   passport_host/oauth/token


### PR DESCRIPTION
Some of the branding info was removed in https://github.com/everydayhero/developer.everydayhero.com/pull/16 but clients need to know which parameters are required to get branding for integrations.
- [x] peer review
- [x] tested (OK'd by PS team)

![everydayhero_api__oauth_integration-2](https://f.cloud.github.com/assets/486512/1303670/8dc03a26-3163-11e3-8e65-df95221cb7a2.jpg)
