### PR TITLE
PS-77 be more explicit as to where V1 and V2 should be used

### DIFF
--- a/content/campaigns.md
+++ b/content/campaigns.md
@@ -3,7 +3,7 @@ title: Campaigns
 ---
 ## List all Campaigns
 
-    GET /campaigns
+    GET https://everydayhero.com/api/v2/campaigns
 
 ### Visibility
 
@@ -22,7 +22,7 @@ retrieved.
 
 ## View a single Campaign
 
-    GET /campaigns/:id
+    GET https://everydayhero.com/api/v2/campaigns/:id
 
 [View demo in API console](/console/?query=campaigns/au-0.json) 
 

--- a/content/charities.md
+++ b/content/charities.md
@@ -3,7 +3,7 @@ title: Charities
 ---
 ## List all Charities
 
-    GET /charities
+    GET https://everydayhero.com/api/v2/charities
 
 [View demo in API console](/console/?query=charities.json) 
 
@@ -23,7 +23,7 @@ Charities participating in the specified Campaigns will be retrieved.
 
 ## View a single Charity
 
-    GET /charities/:id
+    GET https://everydayhero.com/api/v2/charities/:id
 
 [View demo in API console](/console/?query=charities/au-8.json) 
 

--- a/content/invitations.md
+++ b/content/invitations.md
@@ -6,7 +6,7 @@ title: Invitations
 Send an invitation to create an individual supporter page to an email
 address.
 
-    POST /individual-pages/invitations
+    POST https://everydayhero.com/api/v2/individual-pages/invitations
 
 ### Visibility
 
@@ -53,7 +53,7 @@ raise. Defaults to a predetermined value.
 Send an invitation to create an individual supporter page for a team to
 an email address.
 
-    POST /team-pages/:team_page_id/invitations
+    POST https://everydayhero.com/api/v2/team-pages/:team_page_id/invitations
 
 ### Visibility
 

--- a/content/join-requests.md
+++ b/content/join-requests.md
@@ -5,7 +5,7 @@ title: Join Requests
 
 Join an existing team with an existing individual page.
 
-    POST /teams/:id/join-requests
+    POST https://everydayhero.com/api/v2/teams/:id/join-requests
 
 ### Visibility
 

--- a/content/leaderboards.md
+++ b/content/leaderboards.md
@@ -10,7 +10,7 @@ assocated pages.
 
 ## List all Leaderboards
 
-    GET /leaderboards
+    GET https://everydayhero.com/api/v2/leaderboards
 
 ### Visibility
 
@@ -28,7 +28,7 @@ the ids 1, 5 and 20
 
 ## View a single Leaderboard
 
-    GET /leaderboards/:id
+    GET https://everydayhero.com/api/v2/leaderboards/:id
 
 ### Visibility
 
@@ -43,7 +43,7 @@ Public.
 Campaign Leaderboards are a way of showing the top supporter pages for a
 particular campaign.
 
-    GET /campaigns/:id/leaderboard
+    GET https://everydayhero.com/api/v2/campaigns/:id/leaderboard
 
 ### Visibility
 

--- a/content/members.md
+++ b/content/members.md
@@ -5,7 +5,7 @@ title: Members
 
 Add an existing page to an existing team.
 
-    POST /teams/:id/members
+    POST https://everydayhero.com/api/v2/teams/:id/members
 
 ### Visibility
 

--- a/content/oauth-integration.md
+++ b/content/oauth-integration.md
@@ -57,7 +57,7 @@ The endpoints are:
 
 ## Authorize endpoint
 
-    GET    passport.edheroz.com/oauth/authorize(.:format)
+    GET    https://passport.everydayhero.com/oauth/authorize(.:format)
 
 The authorization endpoint is defined in the OAuth 2.0 specification
 and is used by OAuth to interact with resource owners, authenticate
@@ -68,7 +68,7 @@ service redirects the useZ back to the client’s redirect URI with the
 response to the authorization request.
 
 ####Example:
-    https://passport.edheroz.com/oauth/authorize?response_type=code&client_id=XXXX&redirect_uri=http://MYAPP.COM/auth/passport/callback&email=john@smith.com
+    https://passport.everydayhero.com/oauth/authorize?response_type=code&client_id=XXXX&redirect_uri=http://MYAPP.COM/auth/passport/callback&email=john@smith.com
 
 ### Parameters & prepopulation
 
@@ -97,14 +97,14 @@ prepopulate the sign-up form for.
 
 ## Token endpoint
 
-    POST   passport_host/oauth/token
+    POST   https://passport.everydayhero.com/oauth/token
 
 The token endpoint is the endpoint on the authorization server where the
 client application exchanges the authorization code, client ID and client
 secret, for an access token.
 
 ####Example:
-    POST passport_host/oauth/token?code=CODE&client_id=XXXX&client_secret=XXXX&grant_type=authorization_code&redirect_uri=http://myapp.com:3000/auth/passport/callback
+    POST https://passport.everydayhero.com/oauth/token?code=CODE&client_id=XXXX&client_secret=XXXX&grant_type=authorization_code&redirect_uri=http://myapp.com:3000/auth/passport/callback
 
 ### Parameters
 

--- a/content/pages.md
+++ b/content/pages.md
@@ -12,7 +12,7 @@ characteristic include 'amount' and 'custom_metric_total'.
 
 ## List all Pages
 
-    GET /pages
+    GET https://everydayhero.com/api/v2/pages
 
 ### Visibility
 
@@ -38,7 +38,7 @@ campaign specified.
 
 ## View a single Page
 
-    GET /pages/:id
+    GET https://everydayhero.com/api/v2/pages/:id
 
 [View demo in API console](/console/?query=pages/1.json)
 
@@ -52,7 +52,7 @@ Public.
 
 ## Create an Individual Page
 
-    POST /pages
+    POST https://everydayhero.com/api/v2/pages
 
 ### Visibility
 

--- a/content/teams.md
+++ b/content/teams.md
@@ -9,7 +9,7 @@ title: Teams
 * Creates a Team, Team Page and sets individual page as team leader
 
 
-      POST /teams
+      POST https://everydayhero.com/api/v2/teams
 
 ### Visibility
 

--- a/content/users.md
+++ b/content/users.md
@@ -7,7 +7,7 @@ title: Users
 
 ## List all Users
 
-    GET /users
+    GET https://passport.everydayhero.com/api/v1/users
 
 ### Visibility
 
@@ -23,7 +23,7 @@ search : _Optional_ **string**. Retrieve only the users with either a name, nick
 
 ## Get current user
 
-    GET passport_host/api/v1/me.json?access_token=xxx
+    GET https://passport.everydayhero.com/api/v1/me.json?access_token=xxx
 
 ### Visibility
 
@@ -35,7 +35,7 @@ access_token : _Required_ **string** User access_token provided by passport auth
 
 ### Example request
 
-    passport_host/api/v1/me.json?access_token=dc2e3c7c72a297e9df6ffdb60a98e4c841ca384dfeca890b2db9800e830xxxxx
+    https://passport.everydayhero.com/api/v1/me.json?access_token=dc2e3c7c72a297e9df6ffdb60a98e4c841ca384dfeca890b2db9800e830xxxxx
 
 ### Response
 
@@ -43,7 +43,7 @@ access_token : _Required_ **string** User access_token provided by passport auth
 
 ## Update a new user with attributes
 
-    PUT passport_host/api/v1/me
+    PUT https://passport.everydayhero.com/api/v1/me
 
 ### Visibility
 
@@ -59,7 +59,7 @@ user[address] : _optional_ **string** Full user address, example: "87 Wickham Te
 
 ### Example request
 
-    PUT passport_host/api/v1/me?access_token=abc&user%5Baddress%5D=someaddress&user%5Bbirthday%5D=1970-01-01
+    PUT https://passport.everydayhero.com/api/v1/me?access_token=abc&user%5Baddress%5D=someaddress&user%5Bbirthday%5D=1970-01-01
 
 ### Repsonse
 


### PR DESCRIPTION
This is my solution to being more explicit where particular API versions should be used. These changes will be further clarified when we draw a line (restructuring the menu) between passport and supporter API endpoints.
- [x] peer review
- [x] tested (OK'd by PS team)

I have done this to all example URL's ... this is just an example:

![everydayhero_api__pages_1](https://f.cloud.github.com/assets/486512/1293983/e323ecd0-3071-11e3-8041-544228d9818a.png)
![everydayhero_api__pages](https://f.cloud.github.com/assets/486512/1293982/e27fb408-3071-11e3-9394-9d0a0dca3c90.png)
