### PR TITLE
PROPOSAL - add example response for authorise endpoint

### DIFF
--- a/content/oauth-integration.md
+++ b/content/oauth-integration.md
@@ -107,6 +107,10 @@ reference
 country
 : _Optional_ **string**. The country code associated with your campaign (au, nz, uk)
 
+### Response
+
+<%= json :authorizedata %>
+
 ## Token endpoint
 
     POST   https://passport.everydayhero.com/oauth/token

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -268,6 +268,10 @@ module EverydayHero
       users: [UserData, UserData]
     }
 
+    Authorizedata = {
+      code: "a1d74c4c1d137662fdf69615b825e4c83fa02e25"
+    }
+
     Tokendata = {
       access_token: "xxxxxxca4e6d9d09f1d6b1330ccf97d862a7b42e87c737195f90e508d0xxxxxx",
       token_type: "bearer",


### PR DESCRIPTION
Every endpoint has an example response except this one. We are aiming for consistency here :-) Also this makes it a bit difficult for clients who are trying to integrate with us.
- [x] @HelenRoss 
- [x] @antfrew 
- [x] kate
- [x] @joelr 
