### PR TITLE
PROPOSAL - more details for the user address field

### DIFF
--- a/content/users.md
+++ b/content/users.md
@@ -59,7 +59,7 @@ access_token : _Required_ **string** User access_token provided by passport auth
 
 user[birthday] : _optional_ **string** User birthday, format "YYYY-MM-DD".
 
-user[address] : _optional_ **string** Full user address, example: "87 Wickham Terrace, Spring Hill, 4055, QLD"
+user[address] : _optional_ **string** The address passed through must be locatable through the Google Maps API. Example: "87 Wickham Terrace, Spring Hill, 4000, QLD"
 
 ### Example
 


### PR DESCRIPTION
Users integrating with our platform frequently (most of the time) attempt to update the address with a completely bohus value (like 'bla') not realising that we do a lookup with google and split the value into its components before saving.

As a bonus I have corrected our address postcode.

BEFORE

![screen shot 2013-10-21 at 9 17 18 am](https://f.cloud.github.com/assets/486512/1369222/dcdb008c-39dd-11e3-9279-27aaf29e0a69.png)

AFTER

![screen shot 2013-10-21 at 9 17 00 am](https://f.cloud.github.com/assets/486512/1369224/dffcab1c-39dd-11e3-8e88-cbf6c8276f0f.png)

---
- [ ] @HelenRoss 
- [ ] @antfrew 
- [ ] kate
- [ ] dev
