### PR TITLE
correct page data

### DIFF
--- a/content/pages.md
+++ b/content/pages.md
@@ -107,4 +107,4 @@ UK specific fundraising criteria.
 
 ### Response
 
-<%= json :page %>
+<%= json :created_page %>

--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -146,14 +146,18 @@ module EverydayHero
     }
 
     Page = {
-      page: PageData.merge({campaign_date: nil}),
-      meta: {
-        url: "https://TestCampaignForAPI.edherox.com/au/tim"
-      },
+      page: PageData
     }
 
     Pages = {
       pages: [PageData]
+    }
+
+    CreatedPage = {
+      page: PageData.merge({campaign_date: nil}),
+      meta: {
+        url: "https://test-campaign-for-api.edherox.com/au/tim"
+      },
     }
 
     TeamPageData = {


### PR DESCRIPTION
The same page data was being used for app requests, but retrieving the page has
different data compared to when you create a page. Creating a page has the
following additional attributes:
- page.campaign_date
- meta.url
