### PR TITLE
re-implement styling which I accidentally removed

### DIFF
--- a/content/stylesheets/app.scss
+++ b/content/stylesheets/app.scss
@@ -81,13 +81,20 @@ $input_height: 30px;
   @include vendor(box-shadow, $shadow);
 }
 
+html, body, h1, h2, h3, h4, h5, ul, li, div,
+article, aside, details, figcaption, figure,
+footer, header, hgroup, menu, nav, section {
+  margin: 0;
+  padding: 0;
+  font-family: $font_stack;
+}
+
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
   display: block;
 }
 
 body {
-  //background: $background;
   background: $light url("../images/bg.jpeg") center top no-repeat;
   background-attachment: fixed;
 }


### PR DESCRIPTION
I removed the following non-standard CSS in #45 which was actually required for the site to look decent.

``` css
* {
  margin: 0;
  padding: 0;
  font-family: $font_stack;
}
```

This is my attempt at re-implementing it using W3C compliant CSS.
