### PR TITLE
remove user#index

### DIFF
--- a/content/users.md
+++ b/content/users.md
@@ -5,24 +5,6 @@ title: Users
 * TOC
 {:toc}
 
-## List all Users <small>(requires authentication)</small>
-
-    GET https://passport.everydayhero.com/api/v1/users
-
-### Parameters
-
-<div>search : _optional_ **string**</div>
-<div>Retrieve only the users with either a name, nickname or email matching the
-provided keyword(s).</div>
-
-### Example
-
-    https://passport.everydayhero.com/api/v1/users.json
-
-### Response
-
-<%= json :users %>
-
 ## Get current user <small>(requires authentication)</small>
 
     GET https://passport.everydayhero.com/api/v1/me.json?access_token=xxx


### PR DESCRIPTION
The following exists in our API documentation:

![everydayhero_api__users](https://f.cloud.github.com/assets/486512/1569843/6147a2f2-50d7-11e3-8c81-aff8739e92b6.jpg)

But it doesn't seem to have existed in passport OR supporter. These are the V1 routes for passport:

```
        api_v1_me GET    /api/v1/me(.:format)           api/v1/users#show
                  PUT    /api/v1/me(.:format)           api/v1/users#update
  api_v1_branding PUT    /api/v1/branding/:id(.:format) api/v1/branding#update
                  DELETE /api/v1/branding/:id(.:format) api/v1/branding#destroy
```

These are the V1 routes for supporter:

```
   api_v1_page_team POST  /api/v1/pages/:page_id/team(.:format)        api/v1/teams#create {:format=>:json}
  api_v1_page_posts POST  /api/v1/pages/:page_id/posts(.:format)       api/v1/posts#create {:format=>:json}
       api_v1_pages POST  /api/v1/pages(.:format)                      api/v1/pages#create {:format=>:json}
        api_v1_page GET   /api/v1/pages/:id(.:format)                  api/v1/pages#show {:format=>:json}
 api_v1_team_member PATCH /api/v1/teams/:team_id/members/:id(.:format) api/v1/members#update {:format=>:json}
                    PUT   /api/v1/teams/:team_id/members/:id(.:format) api/v1/members#update {:format=>:json}
       api_v1_teams GET   /api/v1/teams(.:format)                      api/v1/teams#index {:format=>:json}
        api_v1_team GET   /api/v1/teams/:id(.:format)                  api/v1/teams#show {:format=>:json}
 api_v1_invitations POST  /api/v1/invitations(.:format)                api/v1/invitations#create {:format=>:json}
   api_v1_charities GET   /api/v1/charities(.:format)                  api/v1/charities#index {:format=>:json}
     api_v1_charity GET   /api/v1/charities/:id(.:format)              api/v1/charities#show {:format=>:json}
   api_v1_campaigns GET   /api/v1/campaigns(.:format)                  api/v1/campaigns#index {:format=>:json}
    api_v1_campaign GET   /api/v1/campaigns/:id(.:format)              api/v1/campaigns#show {:format=>:json}
          api_v1_me GET   /api/v1/me(.:format)                         api/v1/users#show {:format=>:json}
                    PUT   /api/v1/me(.:format)                         api/v1/users#update {:format=>:json}
                    GET   /api/v1/me(.:format)                         api/v1/users#show {:format=>:json}
                    PUT   /api/v1/me(.:format)                         api/v1/users#update {:format=>:json}

```

So basically we can't have details for endpoints which do not exist, so I'm removing it.
