### PR TITLE
address is correctly escaped

### DIFF
--- a/content/users.md
+++ b/content/users.md
@@ -40,7 +40,7 @@ Example: "87 Wickham Terrace, Spring Hill, 4000, QLD"</div>
 
 ### Example
 
-    PUT https://passport.everydayhero.com/api/v1/me?access_token=xxxx&user%5Baddress%5D=someaddress&user%5Bbirthday%5D=1970-01-01
+    PUT https://passport.everydayhero.com/api/v1/me?access_token=xxxx&user%5Baddress%5D=87+Wickham+Terrace,Spring+Hill,4000,QLD&user%5Bbirthday%5D=1970-01-01
 
 ### Repsonse
 


### PR DESCRIPTION
The current example is not correctly escaped. A surprisingly large number of people copy/paste these examples, so they need to be correct.
