### PR TITLE
Remove reference to hljs in JavaScript, which cause error at http://developer.everydayhero.com

### DIFF
--- a/content/javascripts/app.js
+++ b/content/javascripts/app.js
@@ -7,8 +7,6 @@ $(function() {
     $container.text('Available');
   });
 
-  hljs.initHighlightingOnLoad();
-
   $('#run').click(function() {  
     load_api_content($('#path').val());
   });

--- a/content/javascripts/console.js
+++ b/content/javascripts/console.js
@@ -4,10 +4,7 @@ function load_api_content(url) {
     url = url.replace("?","");
     url = url.replace(".json",".jsonp?callback=?&");
     var jqxhr = $.getJSON(url, function(data) {
-       var stringify = JSON.stringify(data, undefined, 2);
-       var prettify = hljs.highlightAuto(stringify).value;
-       prettify = hljs.fixMarkup(prettify);
-       $('#console').html(prettify);
+       $('#console').html(JSON.stringify(data, undefined, 2));
      });
      setTimeout(function(){
        if ($('#console').html() == "Loading") {


### PR DESCRIPTION
highlight.js library is removed at 12c5591edd513f14ffcb3f563bfa5435b2c844f5
It seemed some JavaScript files still refered on hljs variable which was provided by highlight.js. This PR removes these references, though I didn't test this because I couldn't run this app locally.
