### PR TITLE
add missing team example response

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -265,6 +265,10 @@ module EverydayHero
       name: "Team Example"
     }
 
+    Team = {
+      team: TeamData
+    }
+
     Teams = {
       teams: [TeamData]
     }


### PR DESCRIPTION
I accidentally removed this, but its used for the example response for adding team members.
