### PR TITLE
invitations example response data

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -200,8 +200,10 @@ module EverydayHero
       cancelled_at: nil
     }
 
-    JoinTeamInvitationData = InvitationData.merge \
-      team_page_id: 1
+    JoinTeamInvitationData = InvitationData.merge({
+      team_page_id: 1,
+      token: 'xxxxxxxxx'
+    })
 
     CreateIndividualPageInvitation = {
       create_individual_page_invitation: InvitationData


### PR DESCRIPTION
After performing these operations in production I noticed that the example responses are wrong.
- [ ] PR

Actual responses:

```
{"create_individual_page_invitation":{"id":61,"email":"michaeld@everydayhero.com.au","accepted_at":null,"cancelled_at":null}}
```

```
{"join_team_invitation":{"id":62,"email":"michaeld@everydayhero.com.au","accepted_at":null,"cancelled_at":null,"team_page_id":929,"token":"3ac393d8f850b02dd14bf313bafc45a5445605a9"}}
```
# 

![everydayhero_api__invitations-4](https://f.cloud.github.com/assets/486512/1628305/9f298c2c-570b-11e3-84d6-891a944911db.jpg)

![everydayhero_api__invitations-5](https://f.cloud.github.com/assets/486512/1628308/b844cf1e-570b-11e3-963e-98e7d7298f82.jpg)
