### PR TITLE
custom metric fixes

### DIFF
--- a/lib/resources.rb
+++ b/lib/resources.rb
@@ -190,8 +190,7 @@ module EverydayHero
         }
       },
       cached_offline_amount_cents: 0,
-      invitation_id: nil,
-      custom_metric_total: {amount: '100', unit: 'steps'}
+      invitation_id: nil
     }
 
     Teampage = {


### PR DESCRIPTION
Some inconsistencies I found today.

The team creation response does not include custom metrics:

``` bash
curl -v -X POST -H "Authorization: Token token=XXX" -d '{"individual_page_id":650}' 'https://edheroz.com/api/v2/teams'
```

``` json
{
  "page":{
    "id":1532,
    "slug":"team-michael",
    "gift_aid_eligible":false,
    "charity_uid":"au-30",
    "campaign_uid":"au-207",
    "owner_uid":139,
    "owner_type":"Team",
    "uid":1532,
    "state":"active",
    "target_cents":100000000,
    "name":"Team Michael",
    "team_uid":null,
    "team_member_uids":[650],
    "team_leader_page_uid":650,
    "expires_at":"2014-11-29T13:00:00.000Z",
    "amount":{
      "cents":0,
      "currency":{
        "iso_code":"AUD",
        "name":"Australian Dollar",
        "symbol":"$"
      }
    },
    "cached_offline_amount_cents":0,
    "campaign_date":null,
    "fitness_activity_overview":{},
    "invitation_id":null
  }
}
```
