### PR TITLE
Add details for OAuth endpoints

### DIFF
--- a/content/authentication.md
+++ b/content/authentication.md
@@ -32,9 +32,21 @@ To fetch your Client API token, it requires doing the following request:
 
     POST /oauth/token?grant_type=client_credentials&client_id=x&client_secret=x
 
+The retrieved token can be used in the following way
+
+    $ curl -H "Authorization: Bearer <auth_token>" http://example.com
+
+OR using a param of access_token=TOKEN on any request.
+
 This will return JSON containing your OAuth Client token.
 
 ### OAuth User Authentication
 
 After a user connection flow via OAuth, a token will be provided that will be
 usuable on OAuth user scoped API calls.
+
+Identical to OAuth App/Client auth, to use an OAuth User token, set an Authorization Token in this format
+
+    $ curl -H "Authorization: Bearer <auth_token>" http://example.com
+
+OR using a param of access_token=TOKEN on any request.

--- a/content/invitations.md
+++ b/content/invitations.md
@@ -2,7 +2,9 @@
 title: Invitations
 body_id: page_teams
 ---
-## Create Individual Page Invitation <small>(requires authentication)</small>
+## Create Individual Page Invitation
+
+<p class='info'><strong>Authentication types</strong>: Registered Application Token</p>
 
 Send an invitation to create an individual supporter page to an email
 address.
@@ -40,7 +42,9 @@ The amount of money this page is aiming to raise. Defaults to a predetermined va
 
 <%= json :create_individual_page_invitation %>
 
-## Create Join a Team Invitation <small>(requires authentication)</small>
+## Create Join a Team Invitation
+
+<p class='info'><strong>Authentication types</strong>: Registered Application Token</p>
 
 Send an invitation to create an individual supporter page for a team to
 an email address.

--- a/content/join-requests.md
+++ b/content/join-requests.md
@@ -2,7 +2,9 @@
 title: Join Requests
 body_id: page_teams
 ---
-## Create a Join Request <small>(requires authentication)</small>
+## Create a Join Request
+
+<p class='info'><strong>Authentication types</strong>: Registered Application Token or OAuth User Token</p>
 
 Join an existing team with an existing individual page.
 
@@ -12,6 +14,9 @@ Join an existing team with an existing individual page.
 
 individual_page_id : _required_ **integer**<br/>
 The `id` of the page you want to join a team with.
+
+<p class='info'>If using Registered Application authentication, any page in the application's campaign can be used. If using OAuth User authentication the affiliated user must own the page.</p>
+
 
 ### Example
 

--- a/content/members.md
+++ b/content/members.md
@@ -2,7 +2,9 @@
 title: Members
 body_id: page_teams
 ---
-## Add a Team Member <small>(requires authentication)</small>
+## Add a Team Member
+
+<p class='info'><strong>Authentication types</strong>: Registered Application Token or OAuth User Token</p>
 
 Add an existing page to an existing team.
 
@@ -12,6 +14,8 @@ Add an existing page to an existing team.
 
 individual_page_id : _required_ **integer**<br/>
 The `id` of the page you want to join a team with.
+
+<p class='info'>If using Registered Application authentication, any team in the application's campaign can be used. If using OAuth User authentication the affiliated user must own the team.</p>
 
 ### Example
 

--- a/content/pages.md
+++ b/content/pages.md
@@ -109,7 +109,7 @@ charity_id : _optional_ **string**<br/>
 The `id` of the charity to create the page for. A charity will be system nominated if there is none specified.
 
 campaign_id : _required_ **string**<br/>
-The `id` of the campaign to create the page for. A charity will be system nominated if there is none specified.
+The `id` of the campaign to create the page for.
 
 <p class='info'>campaign_id is only required if OAuth User Token authentication is being used, otherwise the registered application's campaign will be used.</p>
 

--- a/content/pages.md
+++ b/content/pages.md
@@ -89,7 +89,9 @@ redirects to
 
 <%= json :expanded_page_data %>
 
-## Create an Individual Page <small>(requires authentication)</small>
+## Create an Individual Page
+
+<p class='info'><strong>Authentication types</strong>: Registered Application Token or OAuth User Token</p>
 
     POST https://everydayhero.com/api/v2/pages
 
@@ -98,11 +100,19 @@ redirects to
 uid : _required_ **integer**<br/>
 The `uid` of the user that you want to create a page for.
 
+<p class='info'>uid is only required if Registered Application Token authentication is being used, otherwise the relevant user affiliated to the token will be used.</p>
+
 birthday : _required_ **string**<br/>
 Your birthday, format "YYYY-MM-DD". In some countries there are age restrictions on fundraising and further action might need to be taken depending on the age provided.
 
 charity_id : _optional_ **string**<br/>
 The `id` of the charity to create the page for. A charity will be system nominated if there is none specified.
+
+campaign_id : _required_ **string**<br/>
+The `id` of the campaign to create the page for. A charity will be system nominated if there is none specified.
+
+<p class='info'>campaign_id is only required if OAuth User Token authentication is being used, otherwise the registered application's campaign will be used.</p>
+
 
 name : _optional_ **string**<br/>
 The desired name for your new supporter page. Defaults to the user's preferred name.

--- a/content/stylesheets/app.scss
+++ b/content/stylesheets/app.scss
@@ -298,6 +298,12 @@ pre {
   padding: 10px;
 }
 
+.info {
+  padding: 15px;
+  background-color: #fcf8e3;
+  margin: 0 0 10px;
+}
+
 pre,
 p code {
   border: 1px solid lighten($dark, 70%);

--- a/content/teams.md
+++ b/content/teams.md
@@ -6,9 +6,11 @@ body_id: page_teams
 * TOC
 {:toc}
 
-## List all Teams <small>(requires authentication)</small>
+## List all Teams
 
-List all teams in the authenticated application's campaign.
+<p class='info'><strong>Authentication types</strong>: Registered Application Token or OAuth User Token</p>
+
+List all teams in the authenticated application's campaign if using Registered Application authentication, or all the user's teams if using OAuth User authentication.
 
     GET https://everydayhero.com/api/v2/teams
 
@@ -38,7 +40,9 @@ Format, 'YYYY-MM-DDThh:mm:ssZ', timestamp optional
 
 <%= json :teams %>
 
-## Create a Team <small>(requires authentication)</small>
+## Create a Team
+
+<p class='info'><strong>Authentication types</strong>: Registered Application Token or OAuth User Token</p>
 
 * Must be created from an existing individual page
 
@@ -51,6 +55,8 @@ Creates a team with team page, and assigns the existing individual page (specifi
 
 individual_page_id : _required_ **integer**<br/>
 The `id` of the individual page which will become the team leader. This page must already exist.
+
+<p class='info'>If using Registered Application authentication, any team in the application's campaign can be used. If using OAuth User authentication the affiliated user must own the team.</p>
 
 name : _optional_ **string**<br/>
 The name of the team. This needs to be unique within the campaign.

--- a/content/totals.md
+++ b/content/totals.md
@@ -10,11 +10,11 @@ title: Totals
 charity_id : _optional_ **string**<br/>
 Charity ID, only totals for that the specified Charity will be retrieved.
 
-campaign_id : _optional_ **string** or **Array**<<br/>
+campaign_id : _optional_ **string** or **Array**<br/>
 Campaign ID, only totals for that the specified Campaign will be retrieved.
 An Array of IDs can be provided, eg: campaign_id[]=au-1&campaign_id[]=au-2
 
-page_id : _optional_ **string**br/>
+page_id : _optional_ **string**<br/>
 Page ID, only totals for that the specified Page will be retrieved.
 
 start_at : _optional_ **string/date-time**<br/>

--- a/content/users.md
+++ b/content/users.md
@@ -5,7 +5,9 @@ title: Users
 * TOC
 {:toc}
 
-## Get current user <small>(requires authentication)</small>
+## Get current user
+
+<p class='info'><strong>Authentication types</strong>: OAuth User Token</p>
 
     GET https://passport.everydayhero.com/api/v1/me
 
@@ -22,7 +24,9 @@ User access_token provided by passport auth hash.
 
 <%= json :user %>
 
-## Update a new user with attributes <small>(requires authentication)</small>
+## Update a new user with attributes
+
+<p class='info'><strong>Authentication types</strong>: OAuth User Token</p>
 
     PUT https://passport.everydayhero.com/api/v1/me
 


### PR DESCRIPTION
Should have done this ages ago, but, document endpoints which can use OAuth, and the differences in params/functionality.

eg:

![screen shot 2015-05-20 at 2 39 21 pm](https://cloud.githubusercontent.com/assets/17657/7719165/368d91c4-ff00-11e4-9eb9-d6cf201d0a91.png)
